### PR TITLE
Session 3 Lifecycle

### DIFF
--- a/lib/content.dart
+++ b/lib/content.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:flutter_training/network.dart';
+import 'package:flutter_training/weather.dart';
+
+class ContentScene extends StatelessWidget {
+  const ContentScene({super.key, required this.network});
+
+  final Network network;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: FractionallySizedBox(
+          widthFactor: 0.5,
+          child: _ContentView(network: network),
+        ),
+      ),
+    );
+  }
+}
+
+class _ContentView extends StatefulWidget {
+  const _ContentView({required this.network});
+
+  final Network network;
+
+  @override
+  _ContentViewState createState() => _ContentViewState();
+}
+
+class _ContentViewState extends State<_ContentView> {
+  Weather? _weather;
+
+  void setWeather(Weather weather) {
+    setState(() {
+      _weather = weather;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const Spacer(),
+        _WeatherView(weather: _weather),
+        Expanded(
+          child: Column(
+            children: [
+              const Padding(padding: EdgeInsets.only(top: 80)),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  TextButton(
+                    onPressed: () {},
+                    child: const Text('Close'),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      widget.network.fetchWeather().then(setWeather);
+                    },
+                    child: const Text('Reload'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _WeatherView extends StatelessWidget {
+  const _WeatherView({
+    super.key,
+    this.weather,
+  });
+
+  final Weather? weather;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        AspectRatio(
+          aspectRatio: 1,
+          child: weather == null
+              ? const Placeholder()
+              : SvgPicture.asset(weather!.fileName.filePath),
+        ),
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 16),
+          child: _TemperatureView(),
+        ),
+      ],
+    );
+  }
+}
+
+class _TemperatureView extends StatelessWidget {
+  const _TemperatureView();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: [
+        Text(
+          '** ℃',
+          style: theme.textTheme.labelLarge?.copyWith(
+            color: theme.colorScheme.primary,
+          ),
+        ),
+        Text(
+          '** ℃',
+          style: theme.textTheme.labelLarge?.copyWith(
+            color: theme.colorScheme.secondary,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/content.dart
+++ b/lib/content.dart
@@ -4,9 +4,15 @@ import 'package:flutter_training/network.dart';
 import 'package:flutter_training/weather.dart';
 
 class ContentScene extends StatelessWidget {
-  const ContentScene({super.key, required this.network});
+  const ContentScene({
+    super.key,
+    required this.network,
+    required this.onContentClose,
+  });
 
   final Network network;
+
+  final VoidCallback onContentClose;
 
   @override
   Widget build(BuildContext context) {
@@ -14,7 +20,10 @@ class ContentScene extends StatelessWidget {
       body: Center(
         child: FractionallySizedBox(
           widthFactor: 0.5,
-          child: _ContentView(network: network),
+          child: _ContentView(
+            network: network,
+            onContentClose: onContentClose,
+          ),
         ),
       ),
     );
@@ -22,9 +31,11 @@ class ContentScene extends StatelessWidget {
 }
 
 class _ContentView extends StatefulWidget {
-  const _ContentView({required this.network});
+  const _ContentView({required this.network, required this.onContentClose});
 
   final Network network;
+
+  final VoidCallback onContentClose;
 
   @override
   _ContentViewState createState() => _ContentViewState();
@@ -53,7 +64,9 @@ class _ContentViewState extends State<_ContentView> {
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: [
                   TextButton(
-                    onPressed: () {},
+                    onPressed: () {
+                      widget.onContentClose();
+                    },
                     child: const Text('Close'),
                   ),
                   TextButton(
@@ -74,7 +87,6 @@ class _ContentViewState extends State<_ContentView> {
 
 class _WeatherView extends StatelessWidget {
   const _WeatherView({
-    super.key,
     this.weather,
   });
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_svg/svg.dart';
+import 'package:flutter_training/content.dart';
 import 'package:flutter_training/network.dart';
-import 'package:flutter_training/weather.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -28,120 +27,12 @@ class MainApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSwatch().copyWith(
           primary: Colors.blue,
           secondary: Colors.red,
+          tertiary: Colors.green,
         ),
       ),
-      home: Scaffold(
-        body: Center(
-          child: FractionallySizedBox(
-            widthFactor: 0.5,
-            child: ContentView(network: network),
-          ),
-        ),
+      home: ContentScene(
+        network: network,
       ),
-    );
-  }
-}
-
-class ContentView extends StatefulWidget {
-  const ContentView({super.key, required this.network});
-
-  final Network network;
-
-  @override
-  ContentViewState createState() => ContentViewState();
-}
-
-class ContentViewState extends State<ContentView> {
-  Weather? _weather;
-
-  void setWeather(Weather weather) {
-    setState(() {
-      _weather = weather;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        const Spacer(),
-        WeatherView(weather: _weather),
-        Expanded(
-          child: Column(
-            children: [
-              const Padding(padding: EdgeInsets.only(top: 80)),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: [
-                  TextButton(
-                    onPressed: () {},
-                    child: const Text('Close'),
-                  ),
-                  TextButton(
-                    onPressed: () {
-                      widget.network.fetchWeather().then(setWeather);
-                    },
-                    child: const Text('Reload'),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class WeatherView extends StatelessWidget {
-  const WeatherView({
-    super.key,
-    this.weather,
-  });
-
-  final Weather? weather;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        AspectRatio(
-          aspectRatio: 1,
-          child: weather == null
-              ? const Placeholder()
-              : SvgPicture.asset(weather!.fileName.filePath),
-        ),
-        const Padding(
-          padding: EdgeInsets.symmetric(vertical: 16),
-          child: TempertureView(),
-        ),
-      ],
-    );
-  }
-}
-
-class TempertureView extends StatelessWidget {
-  const TempertureView({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceAround,
-      children: [
-        Text(
-          '** ℃',
-          style: theme.textTheme.labelLarge?.copyWith(
-            color: theme.colorScheme.primary,
-          ),
-        ),
-        Text(
-          '** ℃',
-          style: theme.textTheme.labelLarge?.copyWith(
-            color: theme.colorScheme.secondary,
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_training/content.dart';
 import 'package:flutter_training/network.dart';
+import 'package:flutter_training/splash.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -30,9 +31,20 @@ class MainApp extends StatelessWidget {
           tertiary: Colors.green,
         ),
       ),
-      home: ContentScene(
-        network: network,
-      ),
+      initialRoute: '/',
+      routes: <String, WidgetBuilder>{
+        '/': (context) => SplashScene(
+              onSplashComplete: () {
+                Navigator.of(context).pushNamed('/content');
+              },
+            ),
+        '/content': (context) => ContentScene(
+              network: StubNetwork(),
+              onContentClose: () {
+                Navigator.of(context).pop();
+              },
+            ),
+      },
     );
   }
 }

--- a/lib/splash.dart
+++ b/lib/splash.dart
@@ -1,7 +1,26 @@
 import 'package:flutter/material.dart';
 
-class SplashScene extends StatelessWidget {
-  const SplashScene({super.key});
+class SplashScene extends StatefulWidget {
+  const SplashScene({super.key, required this.onSplashComplete});
+
+  final VoidCallback onSplashComplete;
+
+  @override
+  State<SplashScene> createState() => _SplashSceneState();
+}
+
+class _SplashSceneState extends State<SplashScene> {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    WidgetsBinding.instance.endOfFrame.then((_) {
+      Future.delayed(const Duration(milliseconds: 500), () {
+        if (mounted) {
+          widget.onSplashComplete();
+        }
+      });
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/splash.dart
+++ b/lib/splash.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class SplashScene extends StatelessWidget {
+  const SplashScene({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(color: Theme.of(context).colorScheme.tertiary);
+  }
+}


### PR DESCRIPTION
## 課題

close #4 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] main.dartの天気予報表示Viewを分割
- [x] Splash用画面追加
- [x] main.dartに遷移管理追加

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

**expected**

https://github.com/MrSmart00/yumemi-flutter-training/assets/8654605/f49c8a74-d19c-49ba-9806-733e1b00542d

**actual**

https://github.com/MrSmart00/yumemi-flutter-training/assets/8654605/e51d1bd6-9ff5-4b0c-bbdb-c052d068dd8e


